### PR TITLE
feat: implement UpdateContentType feature with handler and validator

### DIFF
--- a/AlturaCMS.Application/Features/ContentTypes/Commands/UpdateContentType/UpdateContentTypeCommand.cs
+++ b/AlturaCMS.Application/Features/ContentTypes/Commands/UpdateContentType/UpdateContentTypeCommand.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using MediatR;
 
 namespace AlturaCMS.Application.Features.ContentTypes.Commands.UpdateContentType;
-public class UpdateContentTypeCommand
+public class UpdateContentTypeCommand : IRequest<UpdateContentTypeResponse>
 {
 }

--- a/AlturaCMS.Application/Features/ContentTypes/Commands/UpdateContentType/UpdateContentTypeHandler.cs
+++ b/AlturaCMS.Application/Features/ContentTypes/Commands/UpdateContentType/UpdateContentTypeHandler.cs
@@ -1,10 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using MediatR;
 
 namespace AlturaCMS.Application.Features.ContentTypes.Commands.UpdateContentType;
-public class UpdateContentTypeHandler
+public class UpdateContentTypeHandler : IRequestHandler<UpdateContentTypeCommand, UpdateContentTypeResponse>
 {
+    public Task<UpdateContentTypeResponse> Handle(UpdateContentTypeCommand request, CancellationToken cancellationToken)
+    {
+        throw new NotImplementedException();
+    }
 }

--- a/AlturaCMS.Application/Features/ContentTypes/Commands/UpdateContentType/UpdateContentTypeValidator.cs
+++ b/AlturaCMS.Application/Features/ContentTypes/Commands/UpdateContentType/UpdateContentTypeValidator.cs
@@ -1,10 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using FluentValidation;
 
 namespace AlturaCMS.Application.Features.ContentTypes.Commands.UpdateContentType;
-public class UpdateContentTypeValidator
+public class UpdateContentTypeValidator : AbstractValidator<UpdateContentTypeCommand>
 {
 }


### PR DESCRIPTION
- Added `UpdateContentTypeCommand` class implementing `IRequest<UpdateContentTypeResponse>` in the `AlturaCMS.Application.Features.ContentTypes.Commands.UpdateContentType` namespace.
- Implemented `UpdateContentTypeHandler` class inheriting `IRequestHandler<UpdateContentTypeCommand, UpdateContentTypeResponse>`, including a `Handle` method with a `NotImplementedException` placeholder.
- Added `UpdateContentTypeValidator` class extending `AbstractValidator<UpdateContentTypeCommand>` for validating the command.