### PR TITLE
Improve Dynamic Table Service in AlturaCMS

### DIFF
--- a/AlturaCMS.Application/Features/ContentTypes/Commands/CreateContentType/CreateContentTypeCommand.cs
+++ b/AlturaCMS.Application/Features/ContentTypes/Commands/CreateContentType/CreateContentTypeCommand.cs
@@ -10,8 +10,6 @@ public class CreateContentTypeCommand : IRequest<CreateContentTypeResponse>
 
 public class CreateContentTypeFieldDto
 {
-    public string Slug { get; set; } = string.Empty;
-
     public string Name { get; set; } = string.Empty;
 
     public string DisplayName { get; set; } = string.Empty;
@@ -38,4 +36,7 @@ public class CreateContentTypeFieldDto
 
     public List<string>? AllowedValues { get; set; } = [];
 
+    public string? ReferenceTableName { get; set; }
+
+    public string? ReferenceDisplayFieldName { get; set; }
 }

--- a/AlturaCMS.Application/Features/ContentTypes/Commands/CreateContentType/CreateContentTypeHandler.cs
+++ b/AlturaCMS.Application/Features/ContentTypes/Commands/CreateContentType/CreateContentTypeHandler.cs
@@ -51,7 +51,6 @@ namespace AlturaCMS.Application.Features.ContentTypes.Commands.CreateContentType
                     DisplayName = "Slug",
                     FieldType = FieldType.Text,
                     IsRequired = true,
-                    IsUnique = true,
                     MaxLength = 500,
                     RegexPattern = null
                 });
@@ -71,6 +70,8 @@ namespace AlturaCMS.Application.Features.ContentTypes.Commands.CreateContentType
                         MaxValue = fieldDto.MaxValue,
                         MinValue = fieldDto.MinValue,
                         RegexPattern = fieldDto.RegexPattern,
+                        ReferenceDisplayFieldName = fieldDto.ReferenceDisplayFieldName,
+                        ReferenceTableName = fieldDto.ReferenceTableName
                     });
 
                     if (field != null)

--- a/AlturaCMS.Application/Features/ContentTypes/Commands/CreateContentType/CreateContentTypeValidator.cs
+++ b/AlturaCMS.Application/Features/ContentTypes/Commands/CreateContentType/CreateContentTypeValidator.cs
@@ -20,10 +20,6 @@ public class CreateContentTypeFieldValidator : AbstractValidator<CreateContentTy
 {
     public CreateContentTypeFieldValidator()
     {
-        RuleFor(x => x.Slug)
-            .NotEmpty().WithMessage("Slug is required.")
-            .MaximumLength(100).WithMessage("Slug must not exceed 100 characters.");
-
         RuleFor(x => x.Name)
             .NotEmpty().WithMessage("Name is required.")
             .MaximumLength(100).WithMessage("Name must not exceed 100 characters.");

--- a/AlturaCMS.Application/Services/Persistence/Dynamic/UniqueIdentifierFieldScriptGenerator.cs
+++ b/AlturaCMS.Application/Services/Persistence/Dynamic/UniqueIdentifierFieldScriptGenerator.cs
@@ -14,6 +14,12 @@ public class UniqueIdentifierFieldScriptGenerator : IFieldScriptGenerator
             sb.Append(" NOT NULL");
         }
 
+        // Add foreign key constraint if referenced table and column are provided
+        if (field.ReferenceTableName != null)
+        {
+            sb.Append($" REFERENCES [{DynamicTableService.DynamicTableSchema}].[{field.ReferenceTableName}]([Id])");
+        }
+
         sb.Append(",");
         return sb.ToString();
     }

--- a/AlturaCMS.Application/Services/Persistence/DynamicTableService.cs
+++ b/AlturaCMS.Application/Services/Persistence/DynamicTableService.cs
@@ -8,7 +8,7 @@ namespace AlturaCMS.Application.Services.Persistence;
 public class DynamicTableService : IDynamicTableService
 {
     private readonly string _connectionString;
-    private readonly string schema = "Dynamic";
+    public const string DynamicTableSchema = "Dynamic";
 
     public DynamicTableService(IConfiguration configuration)
     {
@@ -17,7 +17,7 @@ public class DynamicTableService : IDynamicTableService
 
     public async ValueTask<bool> CreateTableAsync(ContentType contentType)
     {
-        var createSchemaScript = GenerateCreateSchemaScript(schema);
+        var createSchemaScript = GenerateCreateSchemaScript(DynamicTableSchema);
         var createTableScript = GenerateCreateTableScript(contentType);
 
         using var connection = new SqlConnection(_connectionString);
@@ -27,6 +27,7 @@ public class DynamicTableService : IDynamicTableService
         await createSchemaCommand.ExecuteNonQueryAsync();
 
         using var createTableCommand = new SqlCommand(createTableScript, connection);
+
         int result = await createTableCommand.ExecuteNonQueryAsync();
 
         // If result is -1, the table was created successfully
@@ -50,7 +51,7 @@ public class DynamicTableService : IDynamicTableService
         }
 
         var sb = new StringBuilder();
-        sb.AppendLine($"CREATE TABLE [{schema}].[{contentType.Name}] (");
+        sb.AppendLine($"CREATE TABLE [{DynamicTableSchema}].[{contentType.Name}] (");
         sb.AppendLine("[Id] UNIQUEIDENTIFIER PRIMARY KEY,");
 
         foreach (var field in contentType.Fields)
@@ -83,8 +84,8 @@ public class DynamicTableService : IDynamicTableService
     {
         var pivotTableName = $"{contentTypeName}_{field.Name}";
         return $@"
-            CREATE TABLE [{schema}].[{pivotTableName}] (
-                [{contentTypeName}Id] UNIQUEIDENTIFIER REFERENCES [{schema}].[{contentTypeName}]([Id]),
+            CREATE TABLE [{DynamicTableSchema}].[{pivotTableName}] (
+                [{contentTypeName}Id] UNIQUEIDENTIFIER REFERENCES [{DynamicTableSchema}].[{contentTypeName}]([Id]),
                 [{field.Name}Id] UNIQUEIDENTIFIER,
                 PRIMARY KEY ([{contentTypeName}Id], [{field.Name}Id])
             );";

--- a/AlturaCMS.Domain/Common/BaseEntity.cs
+++ b/AlturaCMS.Domain/Common/BaseEntity.cs
@@ -45,19 +45,16 @@ public abstract class BaseEntity
     /// Gets or sets the username of the user who created the entity.
     /// </summary>
     [Required]
-    [MaxLength(450)]
     public string CreatedBy { get; set; } = string.Empty;
 
     /// <summary>
     /// Gets or sets the username of the user who last updated the entity.
     /// </summary>
-    [MaxLength(450)]
     public string UpdatedBy { get; set; } = string.Empty;
 
     /// <summary>
     /// Gets or sets the username of the user who deleted the entity.
     /// </summary>
-    [MaxLength(450)]
     public string DeletedBy { get; set; } = string.Empty;
 
     /// <summary>

--- a/AlturaCMS.Domain/Entities/Field.cs
+++ b/AlturaCMS.Domain/Entities/Field.cs
@@ -84,5 +84,17 @@ namespace AlturaCMS.Domain.Entities
         /// </summary>
         /// <value>The list of allowed values for the field or form field.</value>
         public List<string>? AllowedValues { get; set; } = [];
+
+        /// <summary>
+        /// Gets or sets the reference table name for the field or form field.
+        /// </summary>
+        /// <value>The reference table name for the field or form field.</value>
+        public string? ReferenceTableName { get; set; }
+
+        /// <summary>
+        /// Gets or sets a field name from the reference table that we will show in the select or multiselect of the content type.
+        /// </summary>
+        /// <value>The reference table's chosen field name.</value>
+        public string? ReferenceDisplayFieldName { get; set; }
     }
 }

--- a/AlturaCMS.Persistence/Configurations/FieldConfiguration.cs
+++ b/AlturaCMS.Persistence/Configurations/FieldConfiguration.cs
@@ -52,7 +52,12 @@ public class FieldConfiguration : BaseEntityConfiguration<Field>
                 c => c != null ? c.Aggregate(0, (a, v) => HashCode.Combine(a, v.GetHashCode())) : 0,
                 c => c != null ? c.ToList() : new List<string>()));
 
-        builder.HasIndex(e => e.Name)
-            .IsUnique();
+        builder.Property(e => e.ReferenceTableName)
+            .IsRequired(false)
+            .HasMaxLength(500);
+
+        builder.Property(e => e.ReferenceDisplayFieldName)
+            .IsRequired(false)
+            .HasMaxLength(500);
     }
 }

--- a/AlturaCMS.Persistence/Context/DynamicDbContext.cs
+++ b/AlturaCMS.Persistence/Context/DynamicDbContext.cs
@@ -1,9 +1,0 @@
-﻿using Microsoft.EntityFrameworkCore;
-
-namespace AlturaCMS.Persistence.Context;
-public class DynamicDbContext(string connectionString, Action<ModelBuilder> configureModel) : DbContext
-{
-    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder) => optionsBuilder.UseSqlServer(connectionString);
-
-    protected override void OnModelCreating(ModelBuilder modelBuilder) => configureModel(modelBuilder);
-}


### PR DESCRIPTION
This pull request introduces several improvements and refinements to the AlturaCMS project. The changes focus on refactoring existing code for improved maintainability and consistency, adding new features for enhanced flexibility, and fixing issues to ensure proper functionality.

Key Changes:
Refactor: Remove DynamicDbContext Class

The DynamicDbContext class was removed as part of a broader refactoring effort to streamline the persistence layer, reducing complexity and improving efficiency.
Refactor: Remove MaxLength Attributes from BaseEntity Properties

The MaxLength attributes were removed from CreatedBy, UpdatedBy, and DeletedBy properties in BaseEntity. These constraints are now handled in BaseEntityConfiguration, providing a more centralized and maintainable approach to metadata configuration.
Refactor: Remove Slug Validation from CreateContentTypeFieldValidator

Validation rules for the Slug field were removed due to a misunderstanding regarding its necessity in content type creation. This simplifies the validation logic and aligns it with current requirements.
Feature: Add ReferenceTableName and ReferenceDisplayFieldName to Field and DTOs

Introduced ReferenceTableName and ReferenceDisplayFieldName properties to the Field entity and related DTOs. This enhancement allows fields to reference external tables and specify display fields for select and multiselect interfaces, improving content type configurability.
Refactor: Replace Hardcoded Schema String with Constant in DynamicTableService

Replaced occurrences of the hardcoded "Dynamic" schema string with the DynamicTableSchema constant in DynamicTableService. This change improves maintainability and ensures consistent schema usage across the codebase.
Fix: Correct Foreign Key Script Generation for Select Field Types

Fixed foreign key script generation in UniqueIdentifierFieldScriptGenerator to correctly reference fields using select field types. This ensures proper foreign key constraints and maintains referential integrity.