### PR TITLE
Enhance Content Type Creation with Default Metadata Fields and Input Normalization

### DIFF
--- a/AlturaCMS.Application/ApplicationShared.cs
+++ b/AlturaCMS.Application/ApplicationShared.cs
@@ -1,0 +1,89 @@
+﻿using AlturaCMS.Application.Features.ContentTypes.Commands.CreateContentType;
+using AlturaCMS.Domain;
+using AlturaCMS.Domain.Entities;
+
+namespace AlturaCMS.Application
+{
+    public static class ApplicationShared
+    {
+        /// <summary>
+        /// Retrieves a list of default fields used in the content type creation process.
+        /// These fields include metadata such as Slug, CreatedDate, CreatedBy, UpdatedDate,
+        /// UpdatedBy, IsDeleted, DeletedDate, DeletedBy, RowVersion, and IsActive.
+        /// </summary>
+        /// <returns>A list of <see cref="CreateContentTypeFieldDto"/> representing the default fields.</returns>
+        public static List<CreateContentTypeFieldDto> GetDefaultFields()
+        {
+            List<CreateContentTypeFieldDto> fields =
+            [
+                new() {
+                    Name = DomainShared.Constants.DefaultFields.Slug.Name,
+                    DisplayName = DomainShared.Constants.DefaultFields.Slug.DisplayName,
+                    FieldType = FieldType.Text,
+                    IsRequired = true,
+                    IsUnique = true,
+                    MaxLength = DomainShared.Constants.DefaultFields.Slug.MaxLength,
+                    RegexPattern = null
+                },
+                new() {
+                    Name = DomainShared.Constants.DefaultFields.CreatedDate.Name,
+                    DisplayName = DomainShared.Constants.DefaultFields.CreatedDate.DisplayName,
+                    FieldType = FieldType.DateTime,
+                    IsRequired = true
+                },
+                new() {
+                    Name = DomainShared.Constants.DefaultFields.CreatedBy.Name,
+                    DisplayName = DomainShared.Constants.DefaultFields.CreatedBy.DisplayName,
+                    FieldType = FieldType.Text,
+                    IsRequired = true,
+                    MaxLength = DomainShared.Constants.DefaultFields.CreatedBy.MaxLength,
+                    RegexPattern = null
+                },
+                new() {
+                    Name = DomainShared.Constants.DefaultFields.UpdatedDate.Name,
+                    DisplayName = DomainShared.Constants.DefaultFields.UpdatedDate.DisplayName,
+                    FieldType = FieldType.DateTime
+                },
+                new() {
+                    Name = DomainShared.Constants.DefaultFields.UpdatedBy.Name,
+                    DisplayName = DomainShared.Constants.DefaultFields.UpdatedBy.DisplayName,
+                    FieldType = FieldType.Text,
+                    MaxLength = DomainShared.Constants.DefaultFields.UpdatedBy.MaxLength,
+                    RegexPattern = null
+                },
+                new() {
+                    Name = DomainShared.Constants.DefaultFields.IsDeleted.Name,
+                    DisplayName = DomainShared.Constants.DefaultFields.IsDeleted.DisplayName,
+                    FieldType = FieldType.Checkbox,
+                    IsRequired = true
+                },
+                new() {
+                    Name = DomainShared.Constants.DefaultFields.DeletedDate.Name,
+                    DisplayName = DomainShared.Constants.DefaultFields.DeletedDate.DisplayName,
+                    FieldType = FieldType.DateTime
+                },
+                new() {
+                    Name = DomainShared.Constants.DefaultFields.DeletedBy.Name,
+                    DisplayName = DomainShared.Constants.DefaultFields.DeletedBy.DisplayName,
+                    FieldType = FieldType.Text,
+                    MaxLength = DomainShared.Constants.DefaultFields.DeletedBy.MaxLength,
+                    RegexPattern = null
+                },
+                new() {
+                    Name = DomainShared.Constants.DefaultFields.RowVersion.Name,
+                    DisplayName = DomainShared.Constants.DefaultFields.RowVersion.DisplayName,
+                    FieldType = FieldType.Text,
+                    IsRequired = true
+                },
+                new() {
+                    Name = DomainShared.Constants.DefaultFields.IsActive.Name,
+                    DisplayName = DomainShared.Constants.DefaultFields.IsActive.DisplayName,
+                    FieldType = FieldType.Checkbox,
+                    IsRequired = true
+                }
+            ];
+
+            return fields;
+        }
+    }
+}

--- a/AlturaCMS.Application/Features/ContentTypes/Commands/CreateContentType/CreateContentTypeValidator.cs
+++ b/AlturaCMS.Application/Features/ContentTypes/Commands/CreateContentType/CreateContentTypeValidator.cs
@@ -21,6 +21,14 @@ public class CreateContentTypeFieldValidator : AbstractValidator<CreateContentTy
     public CreateContentTypeFieldValidator()
     {
         RuleFor(x => x.Name)
+            .Must((dto, name) => !ApplicationShared.GetDefaultFields().Any(f => f.Name == name))
+            .WithMessage(dto => $"Name '{dto.Name}' is reserved.");
+
+        RuleFor(x => x.DisplayName)
+            .Must((dto, displayName) => !ApplicationShared.GetDefaultFields().Any(f => f.DisplayName == displayName))
+            .WithMessage(dto => $"DisplayName '{dto.DisplayName}' is reserved.");
+
+        RuleFor(x => x.Name)
             .NotEmpty().WithMessage("Name is required.")
             .MaximumLength(100).WithMessage("Name must not exceed 100 characters.");
 

--- a/AlturaCMS.Domain/Common/BaseEntity.cs
+++ b/AlturaCMS.Domain/Common/BaseEntity.cs
@@ -1,6 +1,4 @@
-﻿using System.ComponentModel.DataAnnotations;
-
-namespace AlturaCMS.Domain.Common;
+﻿namespace AlturaCMS.Domain.Common;
 
 /// <summary>
 /// Represents the base entity class with common properties for all entities.
@@ -10,19 +8,32 @@ public abstract class BaseEntity
     /// <summary>
     /// Gets or sets the unique identifier for the entity.
     /// </summary>
-    [Key]
     public Guid Id { get; set; }
 
     /// <summary>
     /// Gets or sets the date and time the entity was created.
     /// </summary>
-    [Required]
     public DateTime CreatedDate { get; set; }
+
+    /// <summary>
+    /// Gets or sets the username of the user who created the entity.
+    /// </summary>
+    public string CreatedBy { get; set; } = string.Empty;
 
     /// <summary>
     /// Gets or sets the date and time the entity was last updated.
     /// </summary>
     public DateTime? UpdatedDate { get; set; }
+
+    /// <summary>
+    /// Gets or sets the username of the user who last updated the entity.
+    /// </summary>
+    public string UpdatedBy { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the entity is active.
+    /// </summary>
+    public bool IsActive { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether the entity is deleted.
@@ -35,27 +46,14 @@ public abstract class BaseEntity
     public DateTime? DeletedDate { get; set; }
 
     /// <summary>
-    /// Gets or sets the version of the row for concurrency control.
-    /// </summary>
-    [Required]
-    [ConcurrencyCheck]
-    public byte[] RowVersion { get; set; }
-
-    /// <summary>
-    /// Gets or sets the username of the user who created the entity.
-    /// </summary>
-    [Required]
-    public string CreatedBy { get; set; } = string.Empty;
-
-    /// <summary>
-    /// Gets or sets the username of the user who last updated the entity.
-    /// </summary>
-    public string UpdatedBy { get; set; } = string.Empty;
-
-    /// <summary>
     /// Gets or sets the username of the user who deleted the entity.
     /// </summary>
-    public string DeletedBy { get; set; } = string.Empty;
+    public string? DeletedBy { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the version of the row for concurrency control.
+    /// </summary>
+    public byte[] RowVersion { get; set; }
 
     /// <summary>
     /// Initializes a new instance of the <see cref="BaseEntity"/> class.
@@ -65,6 +63,6 @@ public abstract class BaseEntity
     {
         CreatedDate = DateTime.UtcNow;
         IsDeleted = false;
-        RowVersion = Array.Empty<byte>();
+        RowVersion = [];
     }
 }

--- a/AlturaCMS.Domain/DomainShared.cs
+++ b/AlturaCMS.Domain/DomainShared.cs
@@ -1,0 +1,73 @@
+﻿namespace AlturaCMS.Domain;
+public static class DomainShared
+{
+    public static class Constants
+    {
+        public static class DefaultFields
+        {
+            public static class Slug
+            {
+                public const string Name = "Slug";
+                public const string DisplayName = "Slug";
+                public const int MaxLength = 500;
+            }
+
+            public static class CreatedDate
+            {
+                public const string Name = "CreatedDate";
+                public const string DisplayName = "Created Date";
+            }
+
+            public static class CreatedBy
+            {
+                public const string Name = "CreatedBy";
+                public const string DisplayName = "Created By";
+                public const int MaxLength = 500;
+            }
+
+            public static class UpdatedDate
+            {
+                public const string Name = "UpdatedDate";
+                public const string DisplayName = "Updated Date";
+            }
+
+            public static class UpdatedBy
+            {
+                public const string Name = "UpdatedBy";
+                public const string DisplayName = "Updated By";
+                public const int MaxLength = 500;
+            }
+
+            public static class IsDeleted
+            {
+                public const string Name = "IsDeleted";
+                public const string DisplayName = "Is Deleted";
+            }
+
+            public static class DeletedDate
+            {
+                public const string Name = "DeletedDate";
+                public const string DisplayName = "Deleted Date";
+            }
+
+            public static class DeletedBy
+            {
+                public const string Name = "DeletedBy";
+                public const string DisplayName = "Deleted By";
+                public const int MaxLength = 500;
+            }
+
+            public static class IsActive
+            {
+                public const string Name = "IsActive";
+                public const string DisplayName = "Is Active";
+            }
+
+            public static class RowVersion
+            {
+                public const string Name = "RowVersion";
+                public const string DisplayName = "Row Version";
+            }
+        }
+    }
+}

--- a/AlturaCMS.Persistence/Configurations/Common/BaseEntityConfiguration.cs
+++ b/AlturaCMS.Persistence/Configurations/Common/BaseEntityConfiguration.cs
@@ -1,4 +1,5 @@
-﻿using AlturaCMS.Domain.Common;
+﻿using AlturaCMS.Domain;
+using AlturaCMS.Domain.Common;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 
@@ -13,17 +14,22 @@ public abstract class BaseEntityConfiguration<T> : IEntityTypeConfiguration<T> w
             .IsRequired();
 
         builder.Property(e => e.RowVersion)
+            .IsRequired()
             .IsRowVersion();
+
+        builder.Property(e => e.IsActive)
+            .IsRequired()
+            .HasDefaultValue(true);
 
         builder.Property(e => e.CreatedBy)
             .IsRequired()
-            .HasMaxLength(500);
+            .HasMaxLength(DomainShared.Constants.DefaultFields.CreatedBy.MaxLength);
 
         builder.Property(e => e.UpdatedBy)
-            .HasMaxLength(500);
+            .HasMaxLength(DomainShared.Constants.DefaultFields.UpdatedBy.MaxLength);
 
         builder.Property(e => e.DeletedBy)
-            .HasMaxLength(500);
+            .HasMaxLength(DomainShared.Constants.DefaultFields.DeletedBy.MaxLength);
 
         // Custom constraint to ensure DeletedDate and DeletedBy are not null if IsDeleted is true
         builder.ToTable(typeof(T).Name, 


### PR DESCRIPTION
- Implemented string input normalization in CreateContentTypeCommandHandler to ensure consistent input formatting.
- Added default metadata fields, including Slug, to new content types for improved consistency.
- Updated field filtering to exclude default metadata fields from responses.
- Applied validation rules to prevent using reserved field names and display names.
- Refactored BaseEntity and BaseEntityConfiguration for consistency and maintainability.